### PR TITLE
fix `.zip` extension check

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,7 +96,7 @@ async function main() {
 
       core.info(`Extracting tarball ${tarball_name}${tarball_ext}`);
 
-      const zig_parent_dir = tarball_ext === 'zip' ?
+      const zig_parent_dir = tarball_ext === '.zip' ?
         await tc.extractZip(tarball_path) :
         await tc.extractTar(tarball_path, null, 'xJ'); // J for xz
 


### PR DESCRIPTION
we were incorrectly checking for the extension to be `zip` instead of `.zip`, so we were always using `extractTar`.  `extractTar` does seem to *work* with zip files though (newer versions of windows have added a `tar` program that works with zip files)...but I fixed the check anyway.