### PR TITLE
add some performance logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,13 +92,18 @@ async function main() {
       const tarball_name = await common.getTarballName();
       const tarball_ext = await common.getTarballExt();
 
+      core.info(`Fetching ${tarball_name}${tarball_ext}`);
+      const fetch_start = Date.now();
       const tarball_path = await retrieveTarball(tarball_name, tarball_ext);
+      core.info(`fetch took ${Date.now() - fetch_start} ms`);
 
       core.info(`Extracting tarball ${tarball_name}${tarball_ext}`);
 
       const zig_parent_dir = tarball_ext === '.zip' ?
+      const extract_start = Date.now();
         await tc.extractZip(tarball_path) :
         await tc.extractTar(tarball_path, null, 'xJ'); // J for xz
+      core.info(`extract took ${Date.now() - extract_start} ms`);
 
       const zig_inner_dir = path.join(zig_parent_dir, tarball_name);
       zig_dir = await tc.cacheDir(zig_inner_dir, 'zig', await common.getVersion());


### PR DESCRIPTION
Here's some example output with the new logging added by this PR marked with `NEW`:
```
NEW | Fetching zig-linux-x86_64-0.13.0.tar.xz
    | Cache Size: ~45 MB (470850[6](https://github.com/marler8997/zigup/actions/runs/9485559170/job/26137781464#step:3:7)0 B)
    | /usr/bin/tar -xf /home/runner/work/_temp/0a690295-c0da-40c8-a309-66[7](https://github.com/marler8997/zigup/actions/runs/9485559170/job/26137781464#step:3:8)c53a9cd93/cache.tzst -P -C /home/runner/work/zigup/zigup --use-compress-program unzstd
    | Cache restored successfully
NEW | fetch took 556 ms
    | Extracting tarball zig-linux-x[8](https://github.com/marler8997/zigup/actions/runs/9485559170/job/26137781464#step:3:9)6_64-0.13.0.tar.xz
    | /usr/bin/tar xJ --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/f08b[9](https://github.com/marler8997/zigup/actions/runs/9485559170/job/26137781464#step:3:10)f5b-55f8-4840-8215-7cffcc1e617a -f /home/runner/work/_temp/zig-linux-x86_64-0.13.0
    | Received 47085060 of 47085060 ([10](https://github.com/marler8997/zigup/actions/runs/9485559170/job/26137781464#step:3:11)0.0%), 44.9 MBs/sec
NEW | extract took 3411 ms
```