### PR TITLE
Add zig.linus.dev mirror

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const CANONICAL = 'https://ziglang.org/builds';
 const MIRRORS = [
   'https://pkg.machengine.org/zig', // slimsag <stephen@hexops.com>
   'https://zigmirror.hryx.net/zig', // hryx <codroid@gmail.com>
+  'https://zig.linus.dev/zig',      // linusg <mail@linusgroh.de>
 ];
 
 async function downloadFromMirror(mirror, tarball_name, tarball_ext) {


### PR DESCRIPTION
As prompted in https://ziglang.org/news/migrate-to-self-hosting/ :^)