### PR TITLE
feat: Add new mirror for `zig`

### DIFF
--- a/mirrors.json
+++ b/mirrors.json
@@ -2,5 +2,6 @@
     [ "https://pkg.machengine.org/zig",      "slimsag <stephen@hexops.com>"     ],
     [ "https://zigmirror.hryx.net/zig",      "hryx <codroid@gmail.com>"         ],
     [ "https://zig.linus.dev/zig",           "linusg <mail@linusgroh.de>"       ],
-    [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>" ]
+    [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>" ],
+    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>"]
 ]

--- a/mirrors.json
+++ b/mirrors.json
@@ -1,7 +1,7 @@
 [
-    [ "https://pkg.machengine.org/zig",      "slimsag <stephen@hexops.com>"     ],
-    [ "https://zigmirror.hryx.net/zig",      "hryx <codroid@gmail.com>"         ],
-    [ "https://zig.linus.dev/zig",           "linusg <mail@linusgroh.de>"       ],
-    [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>" ],
-    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>"]
+    [ "https://pkg.machengine.org/zig",      "slimsag <stephen@hexops.com>"      ],
+    [ "https://zigmirror.hryx.net/zig",      "hryx <codroid@gmail.com>"          ],
+    [ "https://zig.linus.dev/zig",           "linusg <mail@linusgroh.de>"        ],
+    [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>"  ],
+    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>" ]
 ]


### PR DESCRIPTION
Notes for maintainer @mlugg 

- I've read the guide with care ➡️ can confirm that my mirror is acting as you expect
  - Check responsiveness of the mirror at [zig v0.13.0](https://zigmirror.nesovic.dev/zig/zig-linux-x86_64-0.13.0.tar.xz)
- Assigned a dedicated `E2` GCP instance, with caching and their premium edge networking enabled
  - By enabling edge networking, whom ever pulls will have pretty decent dl rate, no mater where my instance actually is with regard to them...
