### PR TITLE
Add `zig.nekos.space` mirror

### DIFF
--- a/mirrors.json
+++ b/mirrors.json
@@ -3,5 +3,6 @@
     [ "https://zigmirror.hryx.net/zig",      "hryx <codroid@gmail.com>"          ],
     [ "https://zig.linus.dev/zig",           "linusg <mail@linusgroh.de>"        ],
     [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>"  ],
-    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>" ]
+    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>" ],
+    [ "https://zig.nekos.space/zig",         "0t4u <rattley@nekos.space>"        ]
 ]


### PR DESCRIPTION
Mirror runs https://github.com/hexops/wrench.

May switch to some type of LRU cache if current system consumes too much disk space.