### PR TITLE
Make cache prefix configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: 'Whether to cache the global Zig cache directory.'
     required: true
     default: true
+  cache-prefix:
+    description: 'An explicit prefix key for restoring and saving the cache'
+    required: false
 runs:
   using: 'node20'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -113,7 +113,8 @@ async function main() {
     core.exportVariable('ZIG_LOCAL_CACHE_DIR', await common.getZigCachePath());
 
     if (core.getBooleanInput('use-cache')) {
-      await cache.restoreCache([await common.getZigCachePath()], await common.getCachePrefix());
+      const prefix = core.getInput('cache-prefix') || await common.getCachePrefix();
+      await cache.restoreCache([await common.getZigCachePath()], prefix);
     }
   } catch (err) {
     core.setFailed(err.message);

--- a/post.js
+++ b/post.js
@@ -17,7 +17,7 @@ async function main() {
       }
 
       if (accessible) {
-        const prefix = await common.getCachePrefix();
+        const prefix = core.getInput('cache-prefix') || await common.getCachePrefix();
         const name = prefix + github.context.runId;
         await cache.saveCache([cache_path], name);
       }


### PR DESCRIPTION
Example:

```yaml
- uses: mlugg/setup-zig@dev
  with:
    version: "0.13.0"
    cache-prefix: "setup-zig-0.13.0-${{ runner.os }}-${{ matrix.foo }}-"
```

Fixes #18