### PR TITLE
Support using `minimum_zig_version` from `build.zig.zon`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This will automatically download Zig and install it to `PATH`.
 You can use `version` to set a Zig version to download. This may be a release (`0.13.0`), a specific nightly
 build (`0.14.0-dev.2+0884a4341`), the string `master` for the latest nightly build, or the string `latest`
 for the latest full release. It can also refer to a [Mach nominated version][mach-nominated], such as
-`2024.5.0-mach`. The default is `latest`.
+`2024.5.0-mach`. Finally, leaving the value empty (the default) will cause the action to attempt to resolve
+the Zig version from the `minimum_zig_version` field in `build.zig.zon`, falling back to `latest` if that
+isn't possible.
 
 ```yaml
   - uses: mlugg/setup-zig@v1

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,8 @@ name: 'Setup Zig Compiler'
 description: 'Download and install the Zig compiler, and cache the global Zig cache'
 inputs:
   version:
-    description: 'Version of the Zig compiler, e.g. "0.13.0" or "0.13.0-dev.351+64ef45eb0". "master" uses the latest nightly build. "latest" uses the latest tagged release.'
-    required: true
-    default: 'latest'
+    description: 'Version of the Zig compiler, e.g. "0.13.0" or "0.13.0-dev.351+64ef45eb0". "master" uses the latest nightly build. "latest" uses the latest tagged release. Leave empty to use minimum_zig_version from build.zig.zon, with a fallback to "latest".'
+    default: ''
   mirror:
     description: 'Override of Zig download mirror to use, e.g. "https://pkg.machengine.org/zig".'
     required: false

--- a/common.js
+++ b/common.js
@@ -9,7 +9,7 @@ const VERSIONS_JSON = 'https://ziglang.org/download/index.json';
 const MACH_VERSIONS_JSON = 'https://pkg.machengine.org/zig/index.json';
 const CACHE_PREFIX = "setup-zig-global-cache-";
 
-const MINIMUM_ZIG_VERSION_REGEX = /\.minimum_zig_version\s*=\s*"(.*?)"/;
+const MINIMUM_ZIG_VERSION_REGEX = /\.\s*minimum_zig_version\s*=\s*"(.*?)"/;
 
 let _cached_version = null;
 async function getVersion() {

--- a/common.js
+++ b/common.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const fs = require('fs');
 const path = require('path');
 const core = require('@actions/core');
 const github = require('@actions/github');
@@ -8,13 +9,33 @@ const VERSIONS_JSON = 'https://ziglang.org/download/index.json';
 const MACH_VERSIONS_JSON = 'https://pkg.machengine.org/zig/index.json';
 const CACHE_PREFIX = "setup-zig-global-cache-";
 
+const MINIMUM_ZIG_VERSION_REGEX = /\.minimum_zig_version\s*=\s*"(.*?)"/;
+
 let _cached_version = null;
 async function getVersion() {
   if (_cached_version != null) {
     return _cached_version;
   }
 
-  const raw = core.getInput('version');
+  let raw = core.getInput('version');
+  if (raw === '') {
+    try {
+      const zon = await fs.promises.readFile('build.zig.zon', 'utf8');
+      const match = MINIMUM_ZIG_VERSION_REGEX.exec(zon);
+
+      if (match !== null) {
+        _cached_version = match[1];
+        return _cached_version;
+      }
+
+      core.info('Failed to find minimum_zig_version in build.zig.zon (using latest)');
+    } catch (e) {
+      core.info(`Failed to read build.zig.zon (using latest): ${e}`);
+    }
+
+    raw = 'latest';
+  }
+
   if (raw === 'master') {
     const resp = await fetch(VERSIONS_JSON);
     const versions = await resp.json();


### PR DESCRIPTION
This is a breaking change since `version` being omitted in the workflow file now has a different meaning from before.

Closes #16.