### PR TITLE
chore: Temporarily remove mirror (maintenance)

### DIFF
--- a/mirrors.json
+++ b/mirrors.json
@@ -3,6 +3,5 @@
     [ "https://zigmirror.hryx.net/zig",      "hryx <codroid@gmail.com>"          ],
     [ "https://zig.linus.dev/zig",           "linusg <mail@linusgroh.de>"        ],
     [ "https://fs.liujiacai.net/zigbuilds",  "jiacai2050 <hello@liujiacai.net>"  ],
-    [ "https://zigmirror.nesovic.dev/zig",   "kaynetik <aleksandar@nesovic.dev>" ],
     [ "https://zig.nekos.space/zig",         "0t4u <rattley@nekos.space>"        ]
 ]


### PR DESCRIPTION
Mirror was introduced with this PR: https://github.com/mlugg/setup-zig/pull/19

I don't know if you would like to comment it out, or remove it altogether. I intend to re-enable it again in a few weeks.

The reason I'm disabling it right now is because I'm doing a major maintenance of my cloud environment, and I do not want to have an unstable mirror until everything is concluded. My expectation is to be done with the maintenance by the 2nd week of June.